### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   check_version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PlanetEaglercraft/autoeagler/security/code-scanning/2](https://github.com/PlanetEaglercraft/autoeagler/security/code-scanning/2)

To resolve the detected issue, we should add an explicit `permissions` block to the workflow YAML. The permissions can be defined either at the workflow root (applying to all jobs by default) or per job if different jobs need different levels of access. For this workflow, both jobs primarily read repository contents (`actions/checkout`, `actions/cache`) but the `nightly` job performs release management (delete tag/release, create release) and deploys to GitHub Pages (publishing files), which require specific write permissions. Therefore, add a least-privilege `permissions` block at the top with the following settings:

- `contents: read` (required by both jobs to check out source code and cache)
- `packages: read` (possibly used with setup-java or cache, but not strictly necessary here)
- `pull-requests: read` (not required, since no PR actions)
- `pages: write` (for GitHub Pages deployment, actions-gh-pages needs this)
- `id-token: write` (sometimes needed for OpenID Connect, not used here)
- `issues: read` (not used)
- `actions: read` (not used)
- `deployments: write` (sometimes needed for releases/pages; cover for deployment actions)
- Ideally, check each action used and set only what is needed—at minimum:  
  - `contents: write` (for releases/tags: covers tag and release creation/deletion)  
  - `pages: write` (for deploying to GitHub Pages)  

Thus, the explicit permissions block to add at the root before `jobs:` should be:

```yaml
permissions:
  contents: write
  pages: write
```

No additional dependencies or external libraries are required.

Edits needed:  
- Insert the `permissions:` block at the root of `.github/workflows/autobuild.yml`, directly after the `on:` block and before `jobs:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
